### PR TITLE
feat: Implement Specification Pattern with Pagination for Product Que…

### DIFF
--- a/Core/Enums/OrderBy.cs
+++ b/Core/Enums/OrderBy.cs
@@ -1,0 +1,6 @@
+﻿namespace Core.Enums;
+public enum OrderBy
+{
+    Ascending,
+    Descending
+}

--- a/Core/Interfaces/IGenericRepository.cs
+++ b/Core/Interfaces/IGenericRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Core.Entities;
+using Core.Interfaces.SpecificationInterfaces;
 using System.Linq.Expressions;
 
 namespace Core.Interfaces;
@@ -9,4 +10,7 @@ public interface IGenericRepository<T> where T : BaseEntity
     Task AddAsync(T entity);
     Task UpdateAsync(T entity);
     Task DeleteAsync(T entity);
+
+    // New method to fetch entities using specifications
+    Task<IList<T>> GetAllWithSpecAsync(ISpecification<T> spec);
 }

--- a/Core/Interfaces/SpecificationInterfaces/IProductSpecification.cs
+++ b/Core/Interfaces/SpecificationInterfaces/IProductSpecification.cs
@@ -1,0 +1,6 @@
+﻿using Core.Entities;
+
+namespace Core.Interfaces.SpecificationInterfaces;
+public interface IProductSpecification : ISpecification<Product>
+{
+}

--- a/Core/Interfaces/SpecificationInterfaces/ISpecification.cs
+++ b/Core/Interfaces/SpecificationInterfaces/ISpecification.cs
@@ -1,0 +1,13 @@
+﻿using System.Linq.Expressions;
+
+namespace Core.Interfaces.SpecificationInterfaces;
+public interface ISpecification<T>
+{
+    Expression<Func<T, bool>> Criteria { get; }
+    List<Expression<Func<T, object>>> Includes { get; }
+    Expression<Func<T, object>> OrderBy { get; }
+    Expression<Func<T, object>> OrderByDescending { get; }
+    int Take { get; }
+    int Skip { get; }
+    bool IsPagingEnabled { get; }
+}

--- a/Core/Specifications/BaseSpecification.cs
+++ b/Core/Specifications/BaseSpecification.cs
@@ -1,0 +1,43 @@
+﻿using Core.Interfaces.SpecificationInterfaces;
+using System.Linq.Expressions;
+
+namespace Core.Specifications;
+public class BaseSpecification<T> : ISpecification<T>
+{
+    public BaseSpecification() { }
+
+    public BaseSpecification(Expression<Func<T, bool>> criteria)
+    {
+        Criteria = criteria;
+    }
+
+    public Expression<Func<T, bool>> Criteria { get; }
+    public List<Expression<Func<T, object>>> Includes { get; } = new List<Expression<Func<T, object>>>();
+    public Expression<Func<T, object>> OrderBy { get; private set; }
+    public Expression<Func<T, object>> OrderByDescending { get; private set; }
+    public int Take { get; private set; }
+    public int Skip { get; private set; }
+    public bool IsPagingEnabled { get; private set; }
+
+    protected void AddInclude(Expression<Func<T, object>> includeExpression)
+    {
+        Includes.Add(includeExpression);
+    }
+
+    protected void AddOrderBy(Expression<Func<T, object>> orderByExpression)
+    {
+        OrderBy = orderByExpression;
+    }
+
+    protected void AddOrderByDescending(Expression<Func<T, object>> orderByDescExpression)
+    {
+        OrderByDescending = orderByDescExpression;
+    }
+
+    protected void ApplyPaging(int skip, int take)
+    {
+        Skip = skip;
+        Take = take;
+        IsPagingEnabled = true;
+    }
+}

--- a/Core/Specifications/ProductSpecification.cs
+++ b/Core/Specifications/ProductSpecification.cs
@@ -1,0 +1,28 @@
+﻿using Core.Entities;
+using Core.Enums;
+
+namespace Core.Specifications;
+public class ProductSpecification : BaseSpecification<Product>
+{
+    public ProductSpecification(string searchTerm, string brand, string typeName, int skip, int take, OrderBy orderBy)
+         : base(x =>
+             (string.IsNullOrEmpty(searchTerm) || x.Name.ToLower().Contains(searchTerm.ToLower())) &&
+             (string.IsNullOrEmpty(brand) || x.ProductBrand.Name.ToLower() == brand.ToLower()) &&
+             (string.IsNullOrEmpty(typeName) || x.ProductType.Name.ToLower() == typeName.ToLower())
+         )
+    {
+        AddInclude(x => x.ProductBrand);
+        AddInclude(x => x.ProductType);
+
+        ApplyPaging(skip, take);
+
+        if (orderBy == Core.Enums.OrderBy.Ascending)
+        {
+            AddOrderBy(x => x.Name);
+        }
+        else
+        {
+            AddOrderByDescending(x => x.Name);
+        }
+    }
+}

--- a/Infrastructure/Data/Repositories/GenericRepository.cs
+++ b/Infrastructure/Data/Repositories/GenericRepository.cs
@@ -1,5 +1,7 @@
 ﻿using Core.Entities;
 using Core.Interfaces;
+using Core.Interfaces.SpecificationInterfaces;
+using Infrastructure.Data.Specifications;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
 
@@ -53,5 +55,17 @@ public class GenericRepository<T> : IGenericRepository<T> where T : BaseEntity
     {
         _context.Set<T>().Remove(entity);
         return Task.CompletedTask;
+    }
+
+    public async Task<IList<T>> GetAllWithSpecAsync(ISpecification<T> spec)
+    {
+        // Apply the specification to the query
+        var query = ApplySpecification(spec);
+        return await query.ToListAsync();
+    }
+
+    private IQueryable<T> ApplySpecification(ISpecification<T> spec)
+    {
+        return SpecificationEvaluator<T>.GetQuery(_context.Set<T>().AsQueryable(), spec);
     }
 }

--- a/Infrastructure/Data/Specifications/SpecificationEvaluator.cs
+++ b/Infrastructure/Data/Specifications/SpecificationEvaluator.cs
@@ -1,0 +1,39 @@
+﻿using Core.Entities;
+using Core.Interfaces.SpecificationInterfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Data.Specifications;
+public class SpecificationEvaluator<TEntity> where TEntity : BaseEntity
+{
+    public static IQueryable<TEntity> GetQuery(IQueryable<TEntity> inputQuery, ISpecification<TEntity> spec)
+    {
+        var query = inputQuery;
+
+        // Apply Criteria (filtering)
+        if (spec.Criteria != null)
+        {
+            query = query.Where(spec.Criteria);
+        }
+
+        // Apply Includes
+        query = spec.Includes.Aggregate(query, (current, include) => current.Include(include));
+
+        // Apply Sorting
+        if (spec.OrderBy != null)
+        {
+            query = query.OrderBy(spec.OrderBy);
+        }
+        else if (spec.OrderByDescending != null)
+        {
+            query = query.OrderByDescending(spec.OrderByDescending);
+        }
+
+        // Apply Paging
+        if (spec.IsPagingEnabled)
+        {
+            query = query.Skip(spec.Skip).Take(spec.Take);
+        }
+
+        return query;
+    }
+}

--- a/Sportify.API/DTOs/ProductDTO.cs
+++ b/Sportify.API/DTOs/ProductDTO.cs
@@ -1,0 +1,12 @@
+﻿namespace Sportify.API.DTOs;
+
+public class ProductDTO
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public double Price { get; set; }
+    public string PictureUrl { get; set; }
+    public string ProductType { get; set; }
+    public string ProductBrand { get; set; }
+}

--- a/Sportify.API/Profiles/MappingProfile.cs
+++ b/Sportify.API/Profiles/MappingProfile.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+using Core.Entities;
+using Sportify.API.DTOs;
+
+namespace Sportify.API.Profiles;
+
+public class MappingProfile : Profile
+{
+    public MappingProfile()
+    {
+        CreateMap<Product, ProductDTO>()
+                   .ForMember(dest => dest.ProductBrand, opt => opt.MapFrom(src => src.ProductBrand.Name))
+                   .ForMember(dest => dest.ProductType, opt => opt.MapFrom(src => src.ProductType.Name));
+    }
+}

--- a/Sportify.API/Program.cs
+++ b/Sportify.API/Program.cs
@@ -19,8 +19,20 @@ public class Program
             opt => opt.UseSqlServer(builder.Configuration.GetConnectionString("SportifyDb")));
         builder.Services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
         builder.Services.AddScoped<IProductRepository, ProductRepository>();
+        builder.Services.AddAutoMapper(typeof(Program));
+
+        builder.Services.AddCors(options =>
+        {
+            options.AddPolicy("AllowAll", builder =>
+                builder.AllowAnyOrigin()
+                       .AllowAnyMethod()
+                       .AllowAnyHeader());
+        });
+
 
         var app = builder.Build();
+
+        app.UseCors("AllowAll");
 
         // Get the logger from the DI container
         var logger = app.Services.GetRequiredService<ILogger<Program>>();

--- a/Sportify.API/Sportify.API.csproj
+++ b/Sportify.API/Sportify.API.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### Implemented Specification Pattern with Pagination for Product Repositories

- Added `BaseSpecification<T>` and `ProductSpecification` in the Core project to define filtering, sorting, and pagination criteria.
- Updated `IGenericRepository<T>` and implemented specification-based querying using `GetAllWithSpecAsync()` method.
- Moved `SpecificationEvaluator<T>` to the Infrastructure project to handle EF Core-specific logic for executing specifications.
- Modified `ProductsController` in the API project to use specification-based filtering and pagination in the `GetProducts` endpoint.
- Enhanced product fetching capabilities to support search, filtering by brand/type, sorting, and pagination.
- Improved the separation of concerns and adherence to Clean Architecture by keeping EF Core-specific logic in Infrastructure.

This PR introduces the Specification Pattern along with pagination to allow more flexible, maintainable, and scalable product queries.
